### PR TITLE
[#5] 검색 결과 페이지 레이아웃 구현

### DIFF
--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,0 +1,74 @@
+import placeData from '../places.json';
+import Image from 'next/image';
+import Link from 'next/link';
+import currency from 'currency.js';
+
+import Header from '@/components/Header';
+import SearchBar from '@/components/SearchBar';
+
+import { PlaceCardProps } from '@/types/place';
+
+const Page = () => {
+  return (
+    <>
+      <Header />
+      <h1 className="text-center text-2xl font-bold my-10">검색 결과 보기</h1>
+      <SearchBar />
+      <section className="w-8/12 mx-auto mt-20">
+        {placeData.map((place) => (
+          <>
+            <SearchResultCard
+              imgUrl={place.imgUrl}
+              name={place.name}
+              location={place.location}
+              price={place.price}
+              score={place.score}
+              id={place.id}
+              key={place.id}
+            />
+            <hr className="w-10/12 mx-auto" />
+          </>
+        ))}
+      </section>
+    </>
+  );
+};
+
+export default Page;
+
+const SearchResultCard = ({
+  imgUrl,
+  name,
+  location,
+  price,
+  score,
+  id,
+}: PlaceCardProps) => {
+  const priceText =
+    price > 0
+      ? `${currency(price, { separator: ',', precision: 1 }).format()}`
+      : '무료';
+  const imgUrlStr = imgUrl ? imgUrl : '/default.png';
+
+  return (
+    <Link href={`/detail/${id}`}>
+      <section className="w-10/12 mx-auto my-5 flex p-1">
+        <Image
+          className="rounded-lg !h-[210px]"
+          src={imgUrlStr}
+          alt={name}
+          width={350}
+          height={250}
+        />
+        <div className="ml-3">
+          <h2 className="font-bold mb-1">{name}</h2>
+          <p className="text-sm text-slate-400 mb-1">{location}</p>
+          <p className=" text-center text-xs w-7 rounded-md font-bold p-0.5 bg-yellow-400">
+            {score}
+          </p>
+        </div>
+        <p className="ml-auto mt-auto text-lg font-bold">{priceText}</p>
+      </section>
+    </Link>
+  );
+};


### PR DESCRIPTION
## 검색 결과 페이지 레이아웃 구현

이슈번호: #5 

기능을 제외한 레이아웃을 우선으로 개발했습니다.

홈페이지와는 다른 카드 컴포넌트를 적용해 검색 결과에서는 더 많은 여행지 목록이 보이도록 했습니다.

<img width="830" alt="image" src="https://github.com/f-lab-edu/Share-The-Journey/assets/123801385/9f2559f9-98ba-4535-bbca-f5ad293325fa">

- `SearchResultCard` 컴포넌트를 따로 분리하는 편이 좋을까요?