### PR TITLE
[#7] 회원가입 페이지 레이아웃 구현

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,3 +1,5 @@
+import Link from 'next/link';
+
 import Header from '@/components/Header';
 
 const Page = () => {
@@ -26,12 +28,14 @@ const Page = () => {
             />
           </label>
           <p className="text-sm text-center my-2">아직 회원이 아니신가요?</p>
-          <button
-            className="block bg-yellow-400 rounded-2xl p-2 w-full mb-3 font-semibold"
-            type="button"
-          >
-            Sign Up
-          </button>
+          <Link href="/signUp">
+            <button
+              className="block bg-yellow-400 rounded-2xl p-2 w-full mb-3 font-semibold"
+              type="button"
+            >
+              Sign Up
+            </button>
+          </Link>
           <button
             className="block bg-green-600 rounded-2xl p-2 w-full text-white font-semibold mb-2"
             type="submit"

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -9,7 +9,7 @@ const Page = () => {
       <h1 className="w-2/4 mx-auto text-center font-bold text-2xl mb-5 mt-32">
         Login
       </h1>
-      <div className="w-2/5 mx-auto rounded-lg bg-slate-100 p-3">
+      <div className="w-2/5 mx-auto rounded-lg bg-slate-100 p-4">
         <form className="mt-1">
           <label className="block">
             이메일

--- a/src/app/signUp/page.tsx
+++ b/src/app/signUp/page.tsx
@@ -10,25 +10,25 @@ const Page = () => {
       <div className="w-2/5 mx-auto rounded-lg bg-slate-100 p-4">
         <form className="mt-1">
           <label className="block">
-            이메일
+            <h3 className="font-semibold">이메일</h3>
             <input
-              className="my-2 rounded-md w-full p-1"
+              className="my-2 rounded-md w-full p-1 px-2"
               type="email"
               name="email"
             />
           </label>
           <label className="block">
-            비밀번호
+            <h3 className="font-semibold">비밀번호</h3>
             <input
-              className="rounded-md w-full my-2 p-1"
+              className="rounded-md w-full my-2 p-1 px-2"
               type="password"
               name="password"
             />
           </label>
           <label className="block">
-            닉네임
+            <h3 className="font-semibold">닉네임</h3>
             <input
-              className="rounded-md w-full my-2 p-1"
+              className="rounded-md w-full my-2 p-1 px-2"
               type="text"
               name="nickname"
             />

--- a/src/app/signUp/page.tsx
+++ b/src/app/signUp/page.tsx
@@ -1,0 +1,48 @@
+import Header from '@/components/Header';
+
+const Page = () => {
+  return (
+    <>
+      <Header />
+      <h1 className="w-2/4 mx-auto text-center font-bold text-2xl mb-5 mt-32">
+        Sign Up
+      </h1>
+      <div className="w-2/5 mx-auto rounded-lg bg-slate-100 p-4">
+        <form className="mt-1">
+          <label className="block">
+            이메일
+            <input
+              className="my-2 rounded-md w-full p-1"
+              type="email"
+              name="email"
+            />
+          </label>
+          <label className="block">
+            비밀번호
+            <input
+              className="rounded-md w-full my-2 p-1"
+              type="password"
+              name="password"
+            />
+          </label>
+          <label className="block">
+            닉네임
+            <input
+              className="rounded-md w-full my-2 p-1"
+              type="text"
+              name="nickname"
+            />
+          </label>
+          <button
+            className="block bg-green-600 rounded-2xl p-2 w-full text-white font-semibold my-2"
+            type="submit"
+          >
+            Sign Up
+          </button>
+        </form>
+      </div>
+    </>
+  );
+};
+
+export default Page;


### PR DESCRIPTION
## 회원가입 페이지 레이아웃 구현

이슈번호: #7 

6번(로그인 페이지 레이아웃) 브랜치에서 분기하여 작업했습니다.

- 이메일 입력란
- 비밀번호 입력란
- 닉네임 입력란

<img width="535" alt="image" src="https://github.com/f-lab-edu/Share-The-Journey/assets/123801385/c64ba350-01df-4faa-bc4d-ba3026d8f02e">
