### PR TITLE
[#23] 여행지 상세 페이지 댓글 기능 구현

### DIFF
--- a/src/app/detail/[id]/page.tsx
+++ b/src/app/detail/[id]/page.tsx
@@ -1,26 +1,13 @@
 import Image from 'next/image';
 import currency from 'currency.js';
-import { format, parse } from 'date-fns';
+
 import { doc, getDoc } from 'firebase/firestore';
 
-import reviewInfo from '../../reviews.json';
-
 import Header from '@/components/Header';
+import ReviewArea from '@/components/ReviewArea';
 import db from '@/app/db';
 
 import { PlaceDetailProps } from '@/types/place';
-
-type Review = {
-  description: string;
-  writer: string;
-  score: number;
-  date: string;
-  review_id: number;
-};
-
-type ReviewProps = {
-  reviews: Review[];
-};
 
 const fetchPlace = async (id: string): Promise<PlaceDetailProps | null> => {
   const docRef = doc(db, 'places', id);
@@ -45,10 +32,6 @@ const Page = async ({ params }: { params: { id: string } }) => {
     );
   }
 
-  // 리뷰는 임시로 고정된 데이터 사용
-  const reviewList: Review[] = reviewInfo.filter(
-    (review) => review.place_id === 1
-  )[0].reviews;
   const imgUrlStr = place.imgUrl ? place.imgUrl : '/default.png';
 
   return (
@@ -62,7 +45,7 @@ const Page = async ({ params }: { params: { id: string } }) => {
         className="!h-[400px] !w-[700px] mx-auto my-20 rounded-lg"
       />
       <PlaceInfo {...place} />
-      <ReviewArea reviews={reviewList} />
+      <ReviewArea placeId={params.id} />
     </>
   );
 };
@@ -101,45 +84,6 @@ const PlaceInfo = ({
       </p>
       <p className="mb-3">편의시설: {amenitiesText}</p>
       <p className=" text-lg font-bold">한줄평: {review}</p>
-    </section>
-  );
-};
-
-const ReviewArea = ({ reviews }: ReviewProps) => {
-  return (
-    <section className="w-9/12 mx-auto  bg-gray-300 p-3 rounded-md mb-10">
-      <h2 className="text-xl font-extrabold mb-5">리뷰</h2>
-      {reviews.length > 0 ? (
-        reviews.map((review) => {
-          const parsedDate = parse(review.date, 'yyyy-MM-dd', new Date());
-          const formattedDate = format(parsedDate, 'yyyy.MM.dd');
-
-          return (
-            <div
-              key={review.review_id}
-              className="mb-5 border p-3 rounded-md bg-white"
-            >
-              <div className="flex justify-between">
-                <h3 className="text-lg font-bold">작성자: {review.writer}</h3>
-                <p className="font-semibold mb-1">
-                  별점: <span className="text-amber-400">{review.score}</span>
-                </p>
-              </div>
-              <p className="mb-1">{review.description}</p>
-              <p className="font-semibold text-zinc-300">
-                작성일: {formattedDate}
-              </p>
-            </div>
-          );
-        })
-      ) : (
-        <p className="mb-5 border p-2 rounded-md bg-white">리뷰가 없습니다.</p>
-      )}
-      <input
-        type="text"
-        placeholder="리뷰를 작성해주세요."
-        className="w-full border p-2 rounded-md h-[100px]"
-      />
     </section>
   );
 };

--- a/src/app/signUp/page.tsx
+++ b/src/app/signUp/page.tsx
@@ -2,9 +2,10 @@
 
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
-import { createUserWithEmailAndPassword, updateProfile } from 'firebase/auth';
+import { createUserWithEmailAndPassword } from 'firebase/auth';
+import { addDoc, collection } from 'firebase/firestore';
 import auth from '@/app/auth';
-
+import db from '@/app/db';
 import Header from '@/components/Header';
 
 const Page = () => {
@@ -18,7 +19,11 @@ const Page = () => {
     createUserWithEmailAndPassword(auth, email, password)
       .then((res) => {
         const user = res.user;
-        return updateProfile(user, { displayName: nickname });
+        return addDoc(collection(db, 'users'), {
+          uid: user.uid,
+          email: user.email,
+          nickname,
+        });
       })
       .then(() => {
         router.push('/');

--- a/src/app/signUp/page.tsx
+++ b/src/app/signUp/page.tsx
@@ -3,7 +3,7 @@
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import { createUserWithEmailAndPassword } from 'firebase/auth';
-import { addDoc, collection } from 'firebase/firestore';
+import { setDoc, doc } from 'firebase/firestore';
 import auth from '@/app/auth';
 import db from '@/app/db';
 import Header from '@/components/Header';
@@ -19,7 +19,8 @@ const Page = () => {
     createUserWithEmailAndPassword(auth, email, password)
       .then((res) => {
         const user = res.user;
-        return addDoc(collection(db, 'users'), {
+        const userRef = doc(db, 'users', user.uid);
+        return setDoc(userRef, {
           uid: user.uid,
           email: user.email,
           nickname,

--- a/src/components/ReviewArea.tsx
+++ b/src/components/ReviewArea.tsx
@@ -46,7 +46,7 @@ const ReviewArea = ({ placeId }: { placeId: string }) => {
     const review = {
       description: newReview,
       writer: user?.displayName ?? '비회원',
-      date: new Date().toISOString().split('T')[0],
+      date: Date.now(),
       place_id: placeId,
       id: '',
     };
@@ -60,8 +60,8 @@ const ReviewArea = ({ placeId }: { placeId: string }) => {
       <h2 className="text-xl font-extrabold mb-5">리뷰</h2>
       {reviews.length > 0 ? (
         reviews.map((review) => {
-          const parsedDate = parse(review.date, 'yyyy-MM-dd', new Date());
-          const formattedDate = format(parsedDate, 'yyyy.MM.dd');
+          const date = new Date(review.date);
+          const formattedDate = format(date, 'yyyy.MM.dd');
 
           return (
             <div

--- a/src/components/ReviewArea.tsx
+++ b/src/components/ReviewArea.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useContext } from 'react';
 import { format, parse } from 'date-fns';
 import {
   collection,
@@ -12,6 +12,7 @@ import {
 
 import db from '@/app/db';
 import { Review } from '@/types/review';
+import { AuthContext } from '@/app/AuthContext';
 
 const addReview = async (placeId: string, review: Omit<Review, 'place_id'>) => {
   const reviewRef = collection(db, 'reviews');
@@ -21,6 +22,7 @@ const addReview = async (placeId: string, review: Omit<Review, 'place_id'>) => {
 const ReviewArea = ({ placeId }: { placeId: string }) => {
   const [newReview, setNewReview] = useState('');
   const [reviews, setReviews] = useState<Review[]>([]);
+  const { user } = useContext(AuthContext);
 
   useEffect(() => {
     const reviewsQuery = query(
@@ -43,7 +45,7 @@ const ReviewArea = ({ placeId }: { placeId: string }) => {
 
     const review = {
       description: newReview,
-      writer: '사용자',
+      writer: user?.displayName ?? '비회원',
       date: new Date().toISOString().split('T')[0],
       place_id: placeId,
       id: '',

--- a/src/components/ReviewArea.tsx
+++ b/src/components/ReviewArea.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { format, parse } from 'date-fns';
+import {
+  collection,
+  addDoc,
+  query,
+  where,
+  onSnapshot,
+} from 'firebase/firestore';
+
+import db from '@/app/db';
+import { Review } from '@/types/review';
+
+const addReview = async (placeId: string, review: Omit<Review, 'place_id'>) => {
+  const reviewRef = collection(db, 'reviews');
+  await addDoc(reviewRef, { ...review, place_id: placeId });
+};
+
+const ReviewArea = ({ placeId }: { placeId: string }) => {
+  const [newReview, setNewReview] = useState('');
+  const [reviews, setReviews] = useState<Review[]>([]);
+
+  useEffect(() => {
+    const reviewsQuery = query(
+      collection(db, 'reviews'),
+      where('place_id', '==', placeId)
+    );
+    const unsubscribe = onSnapshot(reviewsQuery, (querySnapshot) => {
+      const reviewData = querySnapshot.docs.map((doc) => ({
+        ...doc.data(),
+        id: doc.id,
+      })) as Review[];
+      setReviews(reviewData);
+    });
+
+    return () => unsubscribe();
+  }, [placeId]);
+
+  const handleAddReview = async () => {
+    if (newReview.trim() === '') return;
+
+    const review = {
+      description: newReview,
+      writer: '사용자',
+      date: new Date().toISOString().split('T')[0],
+      place_id: placeId,
+      id: '',
+    };
+
+    await addReview(placeId, review);
+    setNewReview('');
+  };
+
+  return (
+    <section className="w-9/12 mx-auto  bg-gray-300 p-3 rounded-md mb-10">
+      <h2 className="text-xl font-extrabold mb-5">리뷰</h2>
+      {reviews.length > 0 ? (
+        reviews.map((review) => {
+          const parsedDate = parse(review.date, 'yyyy-MM-dd', new Date());
+          const formattedDate = format(parsedDate, 'yyyy.MM.dd');
+
+          return (
+            <div
+              key={review.id}
+              className="mb-5 border p-3 rounded-md bg-white"
+            >
+              <div className="flex justify-between">
+                <h3 className="text-lg font-bold">작성자: {review.writer}</h3>
+                {/* <p className="font-semibold mb-1">
+                  별점: <span className="text-amber-400">{review.score}</span>
+                </p> */}
+              </div>
+              <p className="mb-1">{review.description}</p>
+              <p className="font-semibold text-zinc-300">
+                작성일: {formattedDate}
+              </p>
+            </div>
+          );
+        })
+      ) : (
+        <p className="mb-5 border p-2 rounded-md bg-white">리뷰가 없습니다.</p>
+      )}
+      <input
+        type="text"
+        placeholder="리뷰를 작성해주세요."
+        value={newReview}
+        onChange={(e) => setNewReview(e.target.value)}
+        className="w-full border p-2 rounded-md h-[100px]"
+      />
+      <button
+        onClick={handleAddReview}
+        className="w-full bg-blue-500 text-white p-2 rounded-md mt-3"
+      >
+        등록
+      </button>
+    </section>
+  );
+};
+
+export default ReviewArea;

--- a/src/components/ReviewArea.tsx
+++ b/src/components/ReviewArea.tsx
@@ -29,6 +29,7 @@ const ReviewCard = (props: { review: Review }) => {
   const router = useRouter();
 
   const [username, setUsername] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     if (review.writer === '비회원') {
@@ -43,11 +44,7 @@ const ReviewCard = (props: { review: Review }) => {
           setUsername(userDoc.data().nickname);
         }
       } catch (error) {
-        console.error(
-          '데이터를 불러오는데 실패했습니다. 이전 페이지로 이동합니다.',
-          error
-        );
-        router.back();
+        setError('리뷰 정보를 가져오는데 실패했습니다. 다시 시도해주세요.');
       }
     };
 
@@ -56,6 +53,12 @@ const ReviewCard = (props: { review: Review }) => {
 
   if (username === null) {
     return <div>Loading...</div>;
+  } else if (error) {
+    return (
+      <div className="mb-5 text-red-500 font-bold bg-white p-3 rounded-md">
+        {error}
+      </div>
+    );
   }
   return (
     <div key={review.id} className="mb-5 border p-3 rounded-md bg-white">

--- a/src/components/ReviewArea.tsx
+++ b/src/components/ReviewArea.tsx
@@ -11,7 +11,6 @@ import {
   onSnapshot,
   orderBy,
   getDoc,
-  getDocs,
 } from 'firebase/firestore';
 
 import db from '@/app/db';
@@ -23,75 +22,32 @@ const addReview = async (review: Omit<Review, 'id'>) => {
   await setDoc(newReviewRef, { ...review, id: newReviewRef.id });
 };
 
-const fetchNicknames = async (uids: string[]) => {
-  // const nicknames: { [key: string]: string } = {};
-  // for (const uid of uids) {
-  //   const userRef = doc(db, 'users', uid);
-  //   const userDoc = await getDoc(userRef);
-
-  //   if (userDoc.exists()) {
-  //     nicknames[uid] = userDoc.data().nickname;
-  //   }
-  // }
-  // return nicknames;
-  return Promise.all(uids.map(uid => {
-    return getDoc(doc(db, 'users', uid));
-  }))
-    .then(docs => docs.filter(doc => doc.exists))
-    .then(docs => docs.map(doc => doc.data()!))
-    .then(docs => docs.reduce((prev, cur) => {
-      const {uid, nickname} = cur;
-      const newObj: {[key: string]: string} = {}
-      newObj[uid] = nickname
-      return {
-        ...prev,
-        ...newObj,
-      }
-    }, {}))
-    .catch(); 
-  // const usersRef = collection(db, 'users');
-  // const q = query(usersRef, where('uid', 'in', uids)); // uids.length <= 30
-  // return getDocs(q).then(snap => snap.docs.map(doc => doc.data()))
-  // .then(docs => docs.reduce((prev, cur) => {
-  //   const {uid, nickname} = cur;
-  //   const newObj: {[key: string]: string} = {}
-  //   newObj[uid] = nickname
-  //   return {
-  //     ...prev,
-  //     ...newObj,
-  //   }
-  // }, {}));
-};
-
-function ReviewCard(props:{review: Review}) {
-  const {review}= props
+const ReviewCard = (props: { review: Review }) => {
+  const { review } = props;
   const formattedDate = format(new Date(review.date), 'yyyy.MM.dd');
 
   const [username, setUsername] = useState<string | null>(null);
 
   useEffect(() => {
     if (review.writer === '비회원') {
-      setUsername('비회원')
+      setUsername('비회원');
       return;
     }
     const getUserName = async () => {
       const userDoc = await getDoc(doc(db, 'users', review.writer));
       // TODO: 문서를 혹시 못 읽어왔을 때의 예외처리
-      setUsername(userDoc.data()!.nickname)
-    }
+      setUsername(userDoc.data()!.nickname);
+    };
     getUserName().finally(() => {
       // TODO 에러 처리.
     });
-  }, [review.writer])
+  }, [review.writer]);
 
   if (username === null) {
-    return <div>Loading...</div>
+    return <div>Loading...</div>;
   }
   return (
-    <div
-      key={review.id}
-      className="mb-5 border p-3 rounded-md bg-white"
-    >
+    <div key={review.id} className="mb-5 border p-3 rounded-md bg-white">
       <div className="flex justify-between">
         <h3 className="text-lg font-bold">작성자: {username}</h3>
         {/* <p className="font-semibold mb-1">
@@ -99,12 +55,10 @@ function ReviewCard(props:{review: Review}) {
         </p> */}
       </div>
       <p className="mb-1">{review.description}</p>
-      <p className="font-semibold text-zinc-300">
-        작성일: {formattedDate}
-      </p>
+      <p className="font-semibold text-zinc-300">작성일: {formattedDate}</p>
     </div>
-  )
-}
+  );
+};
 
 const ReviewArea = ({ placeId }: { placeId: string }) => {
   const [newReview, setNewReview] = useState('');
@@ -147,7 +101,9 @@ const ReviewArea = ({ placeId }: { placeId: string }) => {
     <section className="w-9/12 mx-auto  bg-gray-300 p-3 rounded-md mb-10">
       <h2 className="text-xl font-extrabold mb-5">리뷰</h2>
       {reviews.length > 0 ? (
-        reviews.map((review, index) => (<ReviewCard key={index} review={review} />))
+        reviews.map((review, index) => (
+          <ReviewCard key={index} review={review} />
+        ))
       ) : (
         <p className="mb-5 border p-2 rounded-md bg-white">리뷰가 없습니다.</p>
       )}

--- a/src/components/ReviewArea.tsx
+++ b/src/components/ReviewArea.tsx
@@ -29,7 +29,7 @@ const ReviewArea = ({ placeId }: { placeId: string }) => {
     const reviewsQuery = query(
       collection(db, 'reviews'),
       where('place_id', '==', placeId),
-      orderBy('date', 'desc')
+      orderBy('date', 'asc')
     );
     const unsubscribe = onSnapshot(reviewsQuery, (querySnapshot) => {
       const reviewData = querySnapshot.docs.map((doc) => ({

--- a/src/components/ReviewArea.tsx
+++ b/src/components/ReviewArea.tsx
@@ -4,9 +4,10 @@ import { useEffect, useState, useContext } from 'react';
 import { format } from 'date-fns';
 import {
   collection,
-  addDoc,
+  setDoc,
   query,
   where,
+  doc,
   onSnapshot,
   orderBy,
 } from 'firebase/firestore';
@@ -15,9 +16,9 @@ import db from '@/app/db';
 import { Review } from '@/types/review';
 import { AuthContext } from '@/app/AuthContext';
 
-const addReview = async (placeId: string, review: Omit<Review, 'place_id'>) => {
-  const reviewRef = collection(db, 'reviews');
-  await addDoc(reviewRef, { ...review, place_id: placeId });
+const addReview = async (review: Omit<Review, 'id'>) => {
+  const newReviewRef = doc(collection(db, 'reviews'));
+  await setDoc(newReviewRef, { ...review, id: newReviewRef.id });
 };
 
 const ReviewArea = ({ placeId }: { placeId: string }) => {
@@ -50,10 +51,9 @@ const ReviewArea = ({ placeId }: { placeId: string }) => {
       writer: user?.displayName ?? '비회원',
       date: Date.now(),
       place_id: placeId,
-      id: '',
     };
 
-    await addReview(placeId, review);
+    await addReview(review);
     setNewReview('');
   };
 

--- a/src/components/ReviewArea.tsx
+++ b/src/components/ReviewArea.tsx
@@ -11,6 +11,7 @@ import {
   onSnapshot,
   orderBy,
   getDoc,
+  getDocs,
 } from 'firebase/firestore';
 
 import db from '@/app/db';
@@ -23,24 +24,91 @@ const addReview = async (review: Omit<Review, 'id'>) => {
 };
 
 const fetchNicknames = async (uids: string[]) => {
-  const nicknames: { [key: string]: string } = {};
-  for (const uid of uids) {
-    const userRef = doc(db, 'users', uid);
-    const userDoc = await getDoc(userRef);
+  // const nicknames: { [key: string]: string } = {};
+  // for (const uid of uids) {
+  //   const userRef = doc(db, 'users', uid);
+  //   const userDoc = await getDoc(userRef);
 
-    if (userDoc.exists()) {
-      nicknames[uid] = userDoc.data().nickname;
-    }
-  }
-  return nicknames;
+  //   if (userDoc.exists()) {
+  //     nicknames[uid] = userDoc.data().nickname;
+  //   }
+  // }
+  // return nicknames;
+  return Promise.all(uids.map(uid => {
+    return getDoc(doc(db, 'users', uid));
+  }))
+    .then(docs => docs.filter(doc => doc.exists))
+    .then(docs => docs.map(doc => doc.data()!))
+    .then(docs => docs.reduce((prev, cur) => {
+      const {uid, nickname} = cur;
+      const newObj: {[key: string]: string} = {}
+      newObj[uid] = nickname
+      return {
+        ...prev,
+        ...newObj,
+      }
+    }, {}))
+    .catch(); 
+  // const usersRef = collection(db, 'users');
+  // const q = query(usersRef, where('uid', 'in', uids)); // uids.length <= 30
+  // return getDocs(q).then(snap => snap.docs.map(doc => doc.data()))
+  // .then(docs => docs.reduce((prev, cur) => {
+  //   const {uid, nickname} = cur;
+  //   const newObj: {[key: string]: string} = {}
+  //   newObj[uid] = nickname
+  //   return {
+  //     ...prev,
+  //     ...newObj,
+  //   }
+  // }, {}));
 };
+
+function ReviewCard(props:{review: Review}) {
+  const {review}= props
+  const formattedDate = format(new Date(review.date), 'yyyy.MM.dd');
+
+  const [username, setUsername] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (review.writer === '비회원') {
+      setUsername('비회원')
+      return;
+    }
+    const getUserName = async () => {
+      const userDoc = await getDoc(doc(db, 'users', review.writer));
+      // TODO: 문서를 혹시 못 읽어왔을 때의 예외처리
+      setUsername(userDoc.data()!.nickname)
+    }
+    getUserName().finally(() => {
+      // TODO 에러 처리.
+    });
+  }, [review.writer])
+
+  if (username === null) {
+    return <div>Loading...</div>
+  }
+  return (
+    <div
+      key={review.id}
+      className="mb-5 border p-3 rounded-md bg-white"
+    >
+      <div className="flex justify-between">
+        <h3 className="text-lg font-bold">작성자: {username}</h3>
+        {/* <p className="font-semibold mb-1">
+          별점: <span className="text-amber-400">{review.score}</span>
+        </p> */}
+      </div>
+      <p className="mb-1">{review.description}</p>
+      <p className="font-semibold text-zinc-300">
+        작성일: {formattedDate}
+      </p>
+    </div>
+  )
+}
 
 const ReviewArea = ({ placeId }: { placeId: string }) => {
   const [newReview, setNewReview] = useState('');
   const [reviews, setReviews] = useState<Review[]>([]);
-  const [userNicknames, setUserNicknames] = useState<{ [key: string]: string }>(
-    {}
-  );
   const { user } = useContext(AuthContext);
 
   useEffect(() => {
@@ -55,12 +123,7 @@ const ReviewArea = ({ placeId }: { placeId: string }) => {
         ...doc.data(),
         id: doc.id,
       })) as Review[];
-
-      const uids = [...new Set(reviewData.map((review) => review.writer))];
-      const nicknames = await fetchNicknames(uids);
-
       setReviews(reviewData);
-      setUserNicknames(nicknames);
     });
 
     return () => unsubscribe();
@@ -84,29 +147,7 @@ const ReviewArea = ({ placeId }: { placeId: string }) => {
     <section className="w-9/12 mx-auto  bg-gray-300 p-3 rounded-md mb-10">
       <h2 className="text-xl font-extrabold mb-5">리뷰</h2>
       {reviews.length > 0 ? (
-        reviews.map((review) => {
-          const date = new Date(review.date);
-          const formattedDate = format(date, 'yyyy.MM.dd');
-          const nickname = userNicknames[review.writer] ?? review.writer;
-
-          return (
-            <div
-              key={review.id}
-              className="mb-5 border p-3 rounded-md bg-white"
-            >
-              <div className="flex justify-between">
-                <h3 className="text-lg font-bold">작성자: {nickname}</h3>
-                {/* <p className="font-semibold mb-1">
-                  별점: <span className="text-amber-400">{review.score}</span>
-                </p> */}
-              </div>
-              <p className="mb-1">{review.description}</p>
-              <p className="font-semibold text-zinc-300">
-                작성일: {formattedDate}
-              </p>
-            </div>
-          );
-        })
+        reviews.map((review, index) => (<ReviewCard key={index} review={review} />))
       ) : (
         <p className="mb-5 border p-2 rounded-md bg-white">리뷰가 없습니다.</p>
       )}

--- a/src/components/ReviewArea.tsx
+++ b/src/components/ReviewArea.tsx
@@ -1,13 +1,14 @@
 'use client';
 
 import { useEffect, useState, useContext } from 'react';
-import { format, parse } from 'date-fns';
+import { format } from 'date-fns';
 import {
   collection,
   addDoc,
   query,
   where,
   onSnapshot,
+  orderBy,
 } from 'firebase/firestore';
 
 import db from '@/app/db';
@@ -27,7 +28,8 @@ const ReviewArea = ({ placeId }: { placeId: string }) => {
   useEffect(() => {
     const reviewsQuery = query(
       collection(db, 'reviews'),
-      where('place_id', '==', placeId)
+      where('place_id', '==', placeId),
+      orderBy('date', 'desc')
     );
     const unsubscribe = onSnapshot(reviewsQuery, (querySnapshot) => {
       const reviewData = querySnapshot.docs.map((doc) => ({

--- a/src/types/review.ts
+++ b/src/types/review.ts
@@ -1,7 +1,7 @@
 export type Review = {
   description: string;
   writer: string;
-  date: string;
+  date: number;
   place_id: string;
   id: string;
 };

--- a/src/types/review.ts
+++ b/src/types/review.ts
@@ -1,0 +1,7 @@
+export type Review = {
+  description: string;
+  writer: string;
+  date: string;
+  place_id: string;
+  id: string;
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,8 @@
     ],
     "paths": {
       "@/*": ["./src/*"]
-    }
+    },
+    "target": "es2015"
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
## 댓글 기능 구현

관련 이슈: #23 

- 여행지 상세 페이지에서 댓글을 작성할 수 있다.
- 로그인한 유저라면 작성자에 유저 이름을 아니라면 비회원이 작성한 댓글임을 명시한다.
- 댓글은 별도의 컬렉션으로 관리되며 어느 여행지의 리뷰인지 여행지의 id를 같이 포함하여 상세 페이지에 들어갔을 때 해당 여행지의 리뷰만 조회할 수 있다.

### 리뷰 요청
- #22 에서 분기된 브랜치 입니다.
- 별점 기능은 추후에 추가 구현하기 위해 우선 주석으로 처리했습니다.
- 리뷰에 관련된 코드의 양이 많아져 컴포넌트를 따로 분리했습니다.