### PR TITLE
[#31] button tag 중첩 문제 수정

### DIFF
--- a/src/app/detail/[id]/page.tsx
+++ b/src/app/detail/[id]/page.tsx
@@ -79,7 +79,7 @@ const PlaceInfo = ({
       </h1>
       <div className="flex justify-between mb-3">
         <h3 className="font-bold mb-3 text-medium text-slate-400">
-          등록자{' '}
+          작성자{' '}
           <p className="font-medium pt-1 text-slate-600 text-sm">
             {registrant}
           </p>

--- a/src/components/HomePlaceCard.tsx
+++ b/src/components/HomePlaceCard.tsx
@@ -1,7 +1,8 @@
 import Link from 'next/link';
 import currency from 'currency.js';
-import { Card, CardHeader, CardFooter, Image, Button } from '@nextui-org/react';
+import { Card, CardHeader, CardFooter, Image } from '@nextui-org/react';
 
+import StarIcon from '@/icons/starIcon';
 import { PlaceCardProps } from '@/types/place';
 
 const HomePlaceCard = ({
@@ -30,7 +31,7 @@ const HomePlaceCard = ({
             <p className="text-tiny text-white/60 uppercase font-bold">
               {location}
             </p>
-            <h4 className="text-white/90 font-medium text-xl">{name}</h4>
+            <h4 className="text-white/90 font-bold text-xl">{name}</h4>
           </CardHeader>
           <Image
             removeWrapper
@@ -38,19 +39,14 @@ const HomePlaceCard = ({
             className="z-0 w-full h-full object-cover"
             src={imgUrlStr}
           />
-          <CardFooter className="absolute bg-black/40 bottom-0 z-10 border-t-1 border-default-600 dark:border-default-100">
-            <div className="flex flex-col flex-grow gap-1 items-start">
-              <p className="text-tiny text-white/60">평점: {score}</p>
-              <p className="text-sm text-white/60">가격: {priceText}</p>
+          <CardFooter className="absolute bg-black/40 bottom-0 z-10 border-t-1 border-default-600 dark:border-default-100 font-semibold text-white/60">
+            <div className="flex items-center justify-between w-full">
+              <div className="flex gap-1">
+                <StarIcon />
+                <p>{score}</p>
+              </div>
+              <p>{priceText}</p>
             </div>
-
-            <Button
-              radius="full"
-              size="md"
-              className="hover:cursor-pointer font-semibold bg-white"
-            >
-              상세보기
-            </Button>
           </CardFooter>
         </Card>
       </Link>


### PR DESCRIPTION
관련 이슈: #31 

- `Navbar` 컴포넌트에 `isPressable` 옵션을 적용하면 `button` 태그가 적용되어 상세보기 `button`과 중첩되는 이슈를 해결.
- 폰트 weight 수정
- 상세페이지 오타 수정

### 수정 이전

![image](https://github.com/user-attachments/assets/b4fb6bfb-0356-4300-a061-1cab37619c3a)

### 수정된 모습

![image](https://github.com/user-attachments/assets/624b02d8-99a4-4a5f-89da-0139f3b6116d)
