### PR TITLE
[#41] 사진 업로드 수정, 캐러셀 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
         "framer-motion": "^11.2.12",
         "next": "14.2.3",
         "react": "^18",
-        "react-dom": "^18"
+        "react-dom": "^18",
+        "swiper": "^11.1.9"
       },
       "devDependencies": {
         "@types/node": "^20",
@@ -8121,6 +8122,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/swiper": {
+      "version": "11.1.9",
+      "resolved": "https://registry.npmjs.org/swiper/-/swiper-11.1.9.tgz",
+      "integrity": "sha512-rflu8zvfGa3x1v/aeSufk4zRJffhOQowyvtJlp46sUBnOqAuk1Rdv5Ldj0AWWBV595iZ+ZMk7VB35ZRtRUomtA==",
+      "funding": [
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/swiperjs"
+        },
+        {
+          "type": "open_collective",
+          "url": "http://opencollective.com/swiper"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.7.0"
       }
     },
     "node_modules/tailwind-merge": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "framer-motion": "^11.2.12",
     "next": "14.2.3",
     "react": "^18",
-    "react-dom": "^18"
+    "react-dom": "^18",
+    "swiper": "^11.1.9"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/src/app/detail/[id]/page.tsx
+++ b/src/app/detail/[id]/page.tsx
@@ -1,10 +1,10 @@
-import Image from 'next/image';
 import currency from 'currency.js';
 
 import { doc, getDoc } from 'firebase/firestore';
 
 import Header from '@/components/Header';
 import ReviewArea from '@/components/ReviewArea';
+import ImgCarousel from '@/components/ImgCarousel';
 import db from '@/app/db';
 
 import { PlaceDetailProps } from '@/types/place';
@@ -42,18 +42,10 @@ const Page = async ({ params }: { params: { id: string } }) => {
     );
   }
 
-  const imgUrlStr = place.imgUrl ? place.imgUrl : '/default.png';
-
   return (
     <>
       <Header />
-      <Image
-        src={imgUrlStr}
-        alt={place.name}
-        width={1200}
-        height={600}
-        className="!h-[400px] !w-[700px] mx-auto my-20 rounded-lg"
-      />
+      <ImgCarousel imgUrls={place.imgUrls} />
       <PlaceInfo {...place} />
       <ReviewArea placeId={params.id} />
     </>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -50,7 +50,7 @@ export default function Home() {
       <section className="mt-10 w-8/12 mx-auto">
         {places.map((place) => (
           <HomePlaceCard
-            imgUrl={place.imgUrl}
+            imgUrls={place.imgUrls}
             name={place.name}
             location={place.location}
             price={place.price}

--- a/src/app/upload/page.tsx
+++ b/src/app/upload/page.tsx
@@ -51,6 +51,12 @@ const Page = () => {
     }
   };
 
+  const encodeFileName = (fileName: string) => {
+    const utf8FileName = new TextEncoder().encode(fileName);
+    const binary = String.fromCharCode(...utf8FileName);
+    return btoa(binary);
+  };
+
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
     const newPlaceValidateInfo = validateNewPlaceForm(newPlace as NewPlaceForm);
@@ -66,7 +72,8 @@ const Page = () => {
       if (files.length > 0) {
         const storage = getStorage();
         const uploadPromises = files.map((file) => {
-          const imageRef = ref(storage, `images/${file.name}`);
+          const encodedFileName = encodeFileName(file.name);
+          const imageRef = ref(storage, `images/${encodedFileName}`);
           return uploadBytes(imageRef, file).then(() =>
             getDownloadURL(imageRef)
           );

--- a/src/app/upload/page.tsx
+++ b/src/app/upload/page.tsx
@@ -79,8 +79,6 @@ const Page = () => {
           );
         });
         imgUrls = await Promise.all(uploadPromises);
-      } else {
-        imgUrls = ['/default.png'];
       }
 
       const newPlaceData = {

--- a/src/components/HomePlaceCard.tsx
+++ b/src/components/HomePlaceCard.tsx
@@ -6,7 +6,7 @@ import StarIcon from '@/icons/starIcon';
 import { PlaceCardProps } from '@/types/place';
 
 const HomePlaceCard = ({
-  imgUrl,
+  imgUrls,
   name,
   score,
   location,
@@ -17,7 +17,6 @@ const HomePlaceCard = ({
     price > 0
       ? `${currency(price, { separator: ',', precision: 1 }).format()}`
       : '무료';
-  const imgUrlStr = imgUrl ? imgUrl : '/default.png';
 
   return (
     <section className="w-9/12 mb-8 mx-auto rounded-xl overflow-hidden">
@@ -37,7 +36,7 @@ const HomePlaceCard = ({
             removeWrapper
             alt="Relaxing app background"
             className="z-0 w-full h-full object-cover"
-            src={imgUrlStr}
+            src={imgUrls[0]}
           />
           <CardFooter className="absolute bg-black/40 bottom-0 z-10 border-t-1 border-default-600 dark:border-default-100 font-semibold text-white/60">
             <div className="flex items-center justify-between w-full">

--- a/src/components/HomePlaceCard.tsx
+++ b/src/components/HomePlaceCard.tsx
@@ -18,6 +18,8 @@ const HomePlaceCard = ({
       ? `${currency(price, { separator: ',', precision: 1 }).format()}`
       : '무료';
 
+  const imgUrlStr = imgUrls[0] ? imgUrls[0] : '/default.png';
+
   return (
     <section className="w-9/12 mb-8 mx-auto rounded-xl overflow-hidden">
       <Link href={`/detail/${id}`}>
@@ -36,7 +38,7 @@ const HomePlaceCard = ({
             removeWrapper
             alt="Relaxing app background"
             className="z-0 w-full h-full object-cover"
-            src={imgUrls[0]}
+            src={imgUrlStr}
           />
           <CardFooter className="absolute bg-black/40 bottom-0 z-10 border-t-1 border-default-600 dark:border-default-100 font-semibold text-white/60">
             <div className="flex items-center justify-between w-full">

--- a/src/components/ImgCarousel.tsx
+++ b/src/components/ImgCarousel.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { Swiper, SwiperSlide } from 'swiper/react';
+import { Navigation, Pagination, EffectCoverflow } from 'swiper/modules';
+import { Swiper as SwiperType } from 'swiper/types';
+import { useState } from 'react';
+import Image from 'next/image';
+
+import 'swiper/css';
+import 'swiper/css/bundle';
+
+const ImgCarousel = ({ imgUrls }: { imgUrls: string[] }) => {
+  const [currentImgIdx, setCurrentImgIdx] = useState<number>(0);
+
+  const swiperParams = {
+    effect: 'coverflow',
+    spaceBetween: 30,
+    slidesPerView: 1.5,
+    initialSlide: currentImgIdx,
+    navigation: true,
+    centeredSlides: true,
+    pagination: { clickable: true },
+    modules: [Navigation, Pagination, EffectCoverflow],
+    onSlideChange: (swiper: SwiperType) => setCurrentImgIdx(swiper.activeIndex),
+    coverflowEffect: {
+      rotate: 50,
+      stretch: 10,
+      depth: 200,
+      modifier: 1,
+      slideShadows: true,
+    },
+    className: 'my-12 w-3/5 flex justify-center mx-auto',
+  };
+
+  return (
+    <Swiper {...swiperParams}>
+      {imgUrls.map((url, idx) => (
+        <SwiperSlide key={idx}>
+          <div className="w-full h-[350px] max-w-[600px] mx-auto">
+            <Image
+              src={url}
+              alt={`Slide image ${idx + 1}`}
+              fill
+              sizes="(max-width: 600px) 100vw, (max-width: 1200px) 50vw, 33vw"
+              className="rounded-lg"
+              priority={idx === 0}
+            />
+          </div>
+        </SwiperSlide>
+      ))}
+    </Swiper>
+  );
+};
+
+export default ImgCarousel;

--- a/src/components/ImgCarousel.tsx
+++ b/src/components/ImgCarousel.tsx
@@ -34,20 +34,34 @@ const ImgCarousel = ({ imgUrls }: { imgUrls: string[] }) => {
 
   return (
     <Swiper {...swiperParams}>
-      {imgUrls.map((url, idx) => (
-        <SwiperSlide key={idx}>
+      {imgUrls && imgUrls.length > 0 ? (
+        imgUrls.map((url, idx) => (
+          <SwiperSlide key={idx}>
+            <div className="w-full h-[350px] max-w-[600px] mx-auto">
+              <Image
+                src={url}
+                alt={`Slide image ${idx + 1}`}
+                fill
+                sizes="(max-width: 600px) 100vw, (max-width: 1200px) 50vw, 33vw"
+                className="rounded-lg"
+                priority={idx === 0}
+              />
+            </div>
+          </SwiperSlide>
+        ))
+      ) : (
+        <SwiperSlide>
           <div className="w-full h-[350px] max-w-[600px] mx-auto">
             <Image
-              src={url}
-              alt={`Slide image ${idx + 1}`}
+              src="/default.png"
+              alt="default image"
               fill
               sizes="(max-width: 600px) 100vw, (max-width: 1200px) 50vw, 33vw"
               className="rounded-lg"
-              priority={idx === 0}
             />
           </div>
         </SwiperSlide>
-      ))}
+      )}
     </Swiper>
   );
 };

--- a/src/components/SearchResult.tsx
+++ b/src/components/SearchResult.tsx
@@ -69,7 +69,7 @@ const SearchResult = () => {
   }, [query]);
 
   return (
-    <section className="w-8/12 mx-auto mt-20">
+    <section className="w-8/12 mx-auto mt-14">
       {error && (
         <>
           <p className="text-2xl text-center text-red-400 font-semibold">
@@ -81,9 +81,9 @@ const SearchResult = () => {
       {!error &&
         searchResult.length > 0 &&
         searchResult.map((place) => (
-          <div key={place.id}>
+          <div key={place.id} className="border-b-1 last:border-0">
             <SearchResultCard {...place} />
-            <hr className="w-10/12 mx-auto" />
+            {/* <hr className="w-10/12 mx-auto " /> */}
           </div>
         ))}
       {!error && searchResult.length === 0 && (

--- a/src/components/SearchResultCard.tsx
+++ b/src/components/SearchResultCard.tsx
@@ -5,7 +5,7 @@ import currency from 'currency.js';
 import { PlaceCardProps } from '@/types/place';
 
 const SearchResultCard = ({
-  imgUrl,
+  imgUrls,
   name,
   location,
   price,
@@ -16,14 +16,13 @@ const SearchResultCard = ({
     price > 0
       ? `${currency(price, { separator: ',', precision: 1 }).format()}`
       : '무료';
-  const imgUrlStr = imgUrl ? imgUrl : '/default.png';
 
   return (
     <Link href={`/detail/${id}`}>
       <section className="w-10/12 mx-auto my-5 flex p-1">
         <Image
           className="rounded-lg !h-[210px]"
-          src={imgUrlStr}
+          src={imgUrls[0]}
           alt={name}
           width={350}
           height={250}

--- a/src/components/SearchResultCard.tsx
+++ b/src/components/SearchResultCard.tsx
@@ -17,12 +17,14 @@ const SearchResultCard = ({
       ? `${currency(price, { separator: ',', precision: 1 }).format()}`
       : '무료';
 
+  const imgUrlStr = imgUrls[0] ? imgUrls[0] : '/default.png';
+
   return (
     <Link href={`/detail/${id}`}>
       <section className="w-10/12 mx-auto my-5 flex p-1">
         <Image
           className="rounded-lg !h-[210px]"
-          src={imgUrls[0]}
+          src={imgUrlStr}
           alt={name}
           width={350}
           height={250}

--- a/src/types/place.ts
+++ b/src/types/place.ts
@@ -1,5 +1,5 @@
 export type PlaceCardProps = {
-  imgUrl?: string;
+  imgUrls: string[];
   name: string;
   location: string;
   price: number;
@@ -20,6 +20,6 @@ export type NewPlaceForm = {
   score: number;
   review: string;
   amenities: string[];
-  imgUrl: string | null;
+  imgUrls: string[];
   registrant: string;
 };


### PR DESCRIPTION
관련 이슈: #41 

## 사진 업로드 수정
- 여러 장의 사진 업로드 가능하게 수정
- places 컬렉션 imgUrls 필드에 imgUrl을 배열로 저장하게 수정

## 카드 컴포넌트 이미지
- imgUrls의 첫 번째 사진을 렌더링

## 캐러셀 구현
- swiper 라이브러리 적용
- 이미지가 한 장 이상이면 캐러셀이 적용됨

### 단일 이미지

![image](https://github.com/user-attachments/assets/df8bdd67-ed94-4f2b-b672-d2a9c5fd3bde)

### 여러장의 이미지

![image](https://github.com/user-attachments/assets/6e04a987-d40d-402f-98dd-528ea2714e80)
